### PR TITLE
feat: add certificate download and services menu link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,6 @@ function App() {
       <Sidebar
         isCollapsed={isSidebarCollapsed}
         activeItem={activeView}
-        onToggleCollapse={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
         onNavigate={handleNavigate}
       />
       

--- a/src/components/AuthorizationManagementView.tsx
+++ b/src/components/AuthorizationManagementView.tsx
@@ -244,6 +244,31 @@ const AuthorizationManagementView: React.FC = () => {
     }
   };
 
+  // Handle single certificate download for an authorization
+  const handleDownloadCertificate = async (authorization: Authorization) => {
+    setIsGenerating(true);
+    try {
+      // Simulate API call delay
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
+      // Simulate file download for the specific authorization
+      const blob = new Blob(['Certificate content'], { type: 'application/pdf' });
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `certificado_autorizacion_${authorization.id}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (error) {
+      console.error('Error generating certificate:', error);
+      alert('Error al generar el certificado');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
   // Handle authorization detail view
   const handleViewAuthorizationDetail = (authorizationId: string) => {
     setSelectedAuthorizationId(authorizationId);
@@ -801,6 +826,17 @@ const AuthorizationManagementView: React.FC = () => {
                                   >
                                     <Edit size={16} className="mr-3" />
                                     Editar
+                                  </button>
+                                )}
+                              </Menu.Item>
+                              <Menu.Item>
+                                {({ active }) => (
+                                  <button
+                                    onClick={() => handleDownloadCertificate(auth)}
+                                    className={`${active ? 'bg-gray-100' : ''} flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100`}
+                                  >
+                                    <Download size={16} className="mr-3" />
+                                    Descargar certificado
                                   </button>
                                 )}
                               </Menu.Item>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,13 +22,12 @@ interface MenuItem {
 interface SidebarProps {
   isCollapsed: boolean;
   activeItem: string;
-  onToggleCollapse: () => void;
   onNavigate: (viewKey: string) => void;
 }
 
 const menuItems: MenuItem[] = [
   { key: 'panel', label: 'Panel interactivo', icon: PieChart, enabled: false },
-  { key: 'servicios', label: 'Gestión de servicios', icon: Briefcase, enabled: false },
+  { key: 'servicios', label: 'Gestión de servicios', icon: Briefcase, enabled: true },
   { key: 'conductores', label: 'Gestión de Conductores', icon: Car, enabled: false },
   { key: 'usuarios', label: 'Gestión de usuarios', icon: Users, enabled: true },
   { key: 'autorizaciones', label: 'Gestión de autorizaciones', icon: FileCheck, enabled: true },
@@ -39,7 +38,6 @@ const menuItems: MenuItem[] = [
 const Sidebar: React.FC<SidebarProps> = ({
   isCollapsed,
   activeItem,
-  onToggleCollapse,
   onNavigate
 }) => {
   return (
@@ -67,7 +65,14 @@ const Sidebar: React.FC<SidebarProps> = ({
           return (
             <button
               key={item.key}
-              onClick={() => item.enabled && onNavigate(item.key)}
+              onClick={() => {
+                if (!item.enabled) return;
+                if (item.key === 'servicios') {
+                  window.open('https://tangerine-yeot-25b9bd.netlify.app/', '_blank');
+                } else {
+                  onNavigate(item.key);
+                }
+              }}
               disabled={!item.enabled}
               className={`
                 w-full flex items-center px-4 py-3 transition-colors duration-200


### PR DESCRIPTION
## Summary
- allow single authorization certificate download via submenu
- enable sidebar services link to open external portal
- remove unused sidebar collapse handler

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 21 errors, mostly @typescript-eslint/no-unused-vars in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68a870a47f348323b4142d94381714c8